### PR TITLE
Reduce image size by using python:3-alpine as the base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3-alpine
 ARG BLACK_VERSION
 RUN pip install --no-cache-dir black==${BLACK_VERSION}
 ENTRYPOINT ["/usr/local/bin/black"]


### PR DESCRIPTION
Hi! Thanks for this docker image, I love the automated tracking of new `black` releases and the public Dockerfile. Currently we're implementing a `black` check in CI by installing black into a container and then running it. Having a pre-built image that's actually kept up to date with releases would be more convenient and save some pipeline time.

I had an improvement I'd like to propose. By using `python:3-alpine` as the base image rather than `python:3-slim`, the image size can be reduced by 59% (from 131MB to 53.7MB with `black, 21.12b0`), resulting in even quicker `pull` times.

I ran a local build in my fork for the comparison:
```
REPOSITORY                        TAG       IMAGE ID       CREATED          SIZE
mccutchen/python-black            latest    51ee405fb74a   2 weeks ago      131MB
docker-python-black-alpine        latest    27fc6b129757   5 minutes ago    53.7MB
```

And verified that the sample run still works as expected (on an unrelated repository I had lying around):
```
$ docker run --rm -v $(pwd):/src docker-python-black-alpine --check --diff /src
--- /src/test.py	2021-12-24 20:26:22.058759 +0000
+++ /src/test.py	2021-12-24 20:26:29.948010 +0000
@@ -1 +1 @@
-FOO = 'bar'
+FOO = "bar"
would reformat /src/test.py
Oh no! 💥 💔 💥
1 file would be reformatted, 17 files would be left unchanged.

$ docker run --rm -v $(pwd):/src docker-python-black-alpine /src
reformatted /src/test.py
All done! ✨ 🍰 ✨
1 file reformatted, 17 files left unchanged.

$ docker run --rm -v $(pwd):/src docker-python-black-alpine --check --diff /src
All done! ✨ 🍰 ✨
18 files would be left unchanged.
```